### PR TITLE
fix: docker version string building

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Install Docker
   apt:
-    name: 'docker-{{ docker_edition }}={{ docker_version }}~{{ docker_edition }}-0~{{ docker_distribution | lower }}'
+    name: 'docker-{{ docker_edition }}={{ docker_version }}~{{ docker_edition }}-0~{{ docker_distribution | lower }}-{{ docker_distribution_release | lower }}'
     state: 'present'
     update_cache: True
     cache_valid_time: '{{ docker_apt_cache_time }}'


### PR DESCRIPTION
Trying to fix #2. Works on Debian 9.2 and Ubuntu 16.04.3