### PR TITLE
Restart docker service after failure

### DIFF
--- a/templates/etc/systemd/system/docker.service.j2
+++ b/templates/etc/systemd/system/docker.service.j2
@@ -26,6 +26,9 @@ TimeoutStartSec=0
 Delegate=yes
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This will restart the docker daemon after a crash/failure.
It is better to have this as default