### PR TITLE
Added docker_daemon_environment for systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ docker_cron_tasks:
     # This uses the standard crontab syntax. 
     schedule: ["0", "0", "*", "*", "0"]
 
-# Docker daemon environment can be used to set environment variables for docker process, such as:
+# Docker daemon options as they would appear on the command line, such as:
+# docker_daemon_options:
+#   - "--dns 8.8.8.8"
+docker_daemon_options: []
+
+# Can be used to set environment variables for the Docker daemon, such as:
 # docker_daemon_environment:
 #   - "HTTP_PROXY=http://proxy.example.com:3128/"
 #   - "HTTPS_PROXY=http://proxy.example.com:3128/"
 #   - "NO_PROXY=localhost,127.0.0.1"
 docker_daemon_environment: []
-
-# Docker daemon options as they would appear on the command line, such as:
-# docker_daemon_options:
-#   - "--dns 8.8.8.8"
-docker_daemon_options: []
 
 # The APT GPG key id used to sign the Docker package.
 docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ docker_cron_tasks:
     # This uses the standard crontab syntax. 
     schedule: ["0", "0", "*", "*", "0"]
 
+# Docker daemon environment can be used to set environment variables for docker process, such as:
+# docker_daemon_environment:
+#   - "HTTP_PROXY=http://proxy.example.com:3128/"
+#   - "HTTPS_PROXY=http://proxy.example.com:3128/"
+#   - "NO_PROXY=localhost,127.0.0.1"
+docker_daemon_environment: []
+
 # Docker daemon options as they would appear on the command line, such as:
 # docker_daemon_options:
 #   - "--dns 8.8.8.8"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ docker_cron_tasks:
     name: "Docker clean up"
     schedule: ["0", "0", "*", "*", "0"]
 
+docker_daemon_environment: []
 docker_daemon_options: []
 
 docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,8 +14,8 @@ docker_cron_tasks:
     name: "Docker clean up"
     schedule: ["0", "0", "*", "*", "0"]
 
-docker_daemon_environment: []
 docker_daemon_options: []
+docker_daemon_environment: []
 
 docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_channel }}"

--- a/templates/etc/systemd/system/docker.service.j2
+++ b/templates/etc/systemd/system/docker.service.j2
@@ -11,6 +11,9 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
+{% if docker_daemon_environment %}
+Environment="{{ docker_daemon_environment | join('" "') }}"
+{% endif %}
 ExecStart=/usr/bin/dockerd {{ docker_daemon_options | join(" ") }}
 ExecReload=/bin/kill -s HUP $MAINPID
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
If use docker in enterprise environments it is often required to use proxy settings for systemd.
https://docs.docker.com/config/daemon/systemd/#httphttps-proxy