### PR TITLE
Added docker_registries, and use built in docker_login to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It is an [Ansible](http://www.ansible.com/home) role to:
 - Configure the Docker daemon's options
 - Set up 1 or more users to run Docker without needing root access
 - Configure a cron job to run Docker clean up commands
+- Login to Docker Registries
 
 ## Why would you want to use this role?
 
@@ -68,6 +69,12 @@ docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansibl
 
 # How long should the apt-cache last in seconds?
 docker_apt_cache_time: 86400
+
+# Want to login to custom Docker Registry?
+docker_registries:
+- registry: "registry.example.com"
+  username: "superuser"
+  password: "superpassword"
 ```
 
 ## Example usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,5 @@ docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_channel }}"
 
 docker_apt_cache_time: 86400
+
+docker_registries: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,3 +96,11 @@
     weekday: "{{ item.schedule[4] }}"
   with_items: "{{ docker_cron_tasks }}"
   when: docker_cron_tasks
+
+- name: Login to Docker Registry
+  docker_login: "{{ registry }}"
+  with_items: "{{ docker_registries }}"
+  loop_control:
+    loop_var: registry
+  become_user: "{{ docker_registry_become_user | default(omit) }}"
+  when: docker_registries


### PR DESCRIPTION
It would be nice if this role also provides a functionality to log in to registries. This will make it more user-friendly for "declarative" approach when instead of tasks. Something like you reference role (e.g. in ansible galaxy dependencies), provide vars, and after that, every other role has docker authenticated.

For me, it sounds a little bit off for the scope of this role. But separate role just for authentication also looks overkill. So, would love feedback on this.