### PR TITLE
Get the Docker package name programmatically from apt-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,6 @@ docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 # Address of the Docker repository.
 docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_channel }}"
 
-# Full APT package name.
-# Note: Docker versions 17.04 to 18.03 do not have that extra ~3 in the middle. 
-docker_apt_package_name: "{{ docker_version }}~{{ docker_edition }}~3-0~{{ ansible_distribution | lower }}"
-
 # How long should the apt-cache last in seconds?
 docker_apt_cache_time: 86400
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,5 @@ docker_daemon_environment: []
 
 docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_channel }}"
-docker_apt_package_name: "{{ docker_version }}~{{ docker_edition }}~3-0~{{ ansible_distribution | lower }}"
 
 docker_apt_cache_time: 86400

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,23 @@
     state: "present"
     update_cache: True
 
+- name: Get Docker package info from the repository
+  shell: apt-cache madison "docker-{{ docker_edition | quote }}" | \
+            grep "{{ docker_channel | quote }}" | \
+            grep "{{ docker_version | quote }}" | \
+            awk -F'|' '{print $2}' |
+            tr -d '[[:space:]]'
+  register: docker_package_info
+
+- name: Set docker_apt_package_name
+  set_fact:
+    docker_apt_package_name: "{{ docker_package_info.stdout }}"
+
+- fail:
+    msg: "Docker edition '{{ docker_edition }}' version '{{ docker_version }}' is not available through the channel '{{ docker_channel }}'"
+  when:
+    docker_apt_package_name == ''
+
 - name: Install Docker
   apt:
     name: "docker-{{ docker_edition }}={{ docker_apt_package_name }}"


### PR DESCRIPTION
This pull request implements tasks to get the value for `docker_apt_package_name` programmatically.

It uses `apt-cache madison`to query the APT repository for docker packages and gets the name of package for the requested edition and version.

This has been tested only on Ubuntu, but `apt-cache` should be available on Debian as well and `grep`, `awk` and `tr` are standard *nix utilities.

Solves https://github.com/nickjj/ansible-docker/issues/18.