### PR TITLE
Fix deprecation warning: use `result is changed` instead of filter

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,7 @@
   command: "systemctl daemon-reload"
   notify: ["Restart Docker"]
   when: (docker_register_systemd_service and
-         docker_register_systemd_service | changed)
+         docker_register_systemd_service is changed)
 
 - name: Add specific users to "docker" group
   user:


### PR DESCRIPTION
Hello @nickjj,

During playbook execution occurs a deprecation warning :

```
TASK [nickjj.docker : Reload systemd daemon] ***********************************
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using 
`result|changed` instead use `result is changed`. This feature will be removed 
in version 2.9. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```

This pull request fixes deprecation warning: use `result is changed` instead of `result|changed`.

Thank you !

Regards,