### PR TITLE
Make it work with ubuntu 18.04

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,11 +18,7 @@
 
 - name: Get upstream APT GPG key
   apt_key:
-    id: "{{ docker_apt_key }}"
-    keyserver: "{{ ansible_local.core.keyserver
-                   if (ansible_local|d() and ansible_local.core|d() and
-                       ansible_local.core.keyserver)
-                   else 'hkp://pool.sks-keyservers.net' }}"
+    url: https://download.docker.com/linux/ubuntu/gpg
     state: "present"
 
 - name: Configure upstream APT repository


### PR DESCRIPTION
With Ubuntu 18.04 in Vagrant, this step was consistently failing with 
```
fatal: [docker]: FAILED! => {"changed": false, "cmd": "/usr/bin/apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv 9DC858229FC7DD38854AE2D88D81803C0EBFCD88", "msg": "Error fetching key 9DC858229FC7DD38854AE2D88D81803C0EBFCD88 from keyserver: hkp://pool.sks-keyservers.net", "rc": 2, "stderr": "Warning: apt-key output should not be parsed (stdout is not a terminal)\ngpg: keyserver receive failed: Server indicated a failure\n", "stderr_lines": ["Warning: apt-key output should not be parsed (stdout is not a terminal)", "gpg: keyserver receive failed: Server indicated a failure"], "stdout": "Executing: /tmp/apt-key-gpghome.acJfzkV416/gpg.1.sh --keyserver hkp://pool.sks-keyservers.net --recv 9DC858229FC7DD38854AE2D88D81803C0EBFCD88\n", "stdout_lines": ["Executing: /tmp/apt-key-gpghome.acJfzkV416/gpg.1.sh --keyserver hkp://pool.sks-keyservers.net --recv 9DC858229FC7DD38854AE2D88D81803C0EBFCD88"]}
```