### PR TITLE
fix issue #18 and fix new sintax of test of Ansible 2.5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,6 @@ docker_daemon_environment: []
 
 docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_channel }}"
-docker_apt_package_name: "{{ docker_version }}~{{ docker_edition }}~3-0~{{ ansible_distribution | lower }}"
+docker_apt_package_name: "{{ docker_version }}~{{ docker_edition }}-0~{{ ansible_distribution | lower }}"
 
 docker_apt_cache_time: 86400

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Fail if Docker version is < 17.03
   fail:
     msg: "docker_version must be >= 17.03, yours is set to {{ docker_version }}."
-  when: docker_version | version_compare("17.03", "<")
+  when: docker_version is version_compare("17.03", "<")
 
 - name: Install Docker and role dependencies
   apt:
@@ -65,7 +65,7 @@
   command: "systemctl daemon-reload"
   notify: ["Restart Docker"]
   when: (docker_register_systemd_service and
-         docker_register_systemd_service | changed)
+         docker_register_systemd_service is changed)
 
 - name: Add specific users to "docker" group
   user:


### PR DESCRIPTION
#18 fixed and use now new sintax of test: https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters
because _using Ansible-provided jinja tests as filters will be removed in Ansible 2.9._