### PR TITLE
fix: update cache before using apt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,8 @@
     name: "{{ item }}"
     state: "present"
     install_recommends: False
+    update_cache: True
+    cache_valid_time: "{{ docker_apt_cache_time }}"
   with_items:
     - "apt-transport-https"
     - "ca-certificates"


### PR DESCRIPTION
Hello, 
The role doesn't update cache before installing role dependencies

```
TASK [nickjj.docker : Install Docker and role dependencies] ****************************************************************************************************************************************************************************************************************************************************************************************************************
failed: [X.X.X.X] (item=[u'apt-transport-https', u'ca-certificates', u'software-properties-common', u'cron']) => {"cache_update_time": 1530198694, "cache_updated": false, "changed": false, "item": ["apt-transport-https", "ca-certificates", "software-properties-common", "cron"], "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'apt-transport-https' -o APT::Install-Recommends=no' failed: E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/a/apt/apt-transport-https_1.2.26_amd64.deb  404  Not Found [IP: 91.189.88.152 80]\n\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "rc": 100, "stderr": "E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/a/apt/apt-transport-https_1.2.26_amd64.deb  404  Not Found [IP: 91.189.88.152 80]\n\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "stderr_lines": ["E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/a/apt/apt-transport-https_1.2.26_amd64.deb  404  Not Found [IP: 91.189.88.152 80]", "", "E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  apt-transport-https\n0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.\nNeed to get 26.1 kB of archives.\nAfter this operation, 215 kB of additional disk space will be used.\nErr:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apt-transport-https amd64 1.2.26\n  404  Not Found [IP: 91.189.88.152 80]\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following NEW packages will be installed:", "  apt-transport-https", "0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.", "Need to get 26.1 kB of archives.", "After this operation, 215 kB of additional disk space will be used.", "Err:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apt-transport-https amd64 1.2.26", "  404  Not Found [IP: 91.189.88.152 80]"]}
```