### PR TITLE
Download latest available version if not specified explicitly

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,9 @@
 docker_edition: "ce"
 docker_channel: "edge"
 
-docker_version: "18.04.0"
+docker_version: "latest"
 docker_install_docker_compose: True
-docker_compose_version: "1.21.0"
+docker_compose_version: "latest"
 
 docker_users: []
 
@@ -19,6 +19,6 @@ docker_daemon_environment: []
 
 docker_apt_key: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 docker_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker_channel }}"
-docker_apt_package_name: "{{ docker_version }}~{{ docker_edition }}~3-0~{{ ansible_distribution | lower }}"
+docker_apt_package_name: "docker-{{ docker_edition }}"
 
 docker_apt_cache_time: 86400

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,9 +33,13 @@
     state: "present"
     update_cache: True
 
+- set_fact:
+    docker_apt_package_name: "docker-{{ docker_edition }}={{ docker_version }}~{{ docker_edition }}~3-0~{{ ansible_distribution | lower }}"
+  when: docker_version != "latest"
+
 - name: Install Docker
   apt:
-    name: "docker-{{ docker_edition }}={{ docker_apt_package_name }}"
+    name: "{{docker_apt_package_name}}"
     state: "present"
     update_cache: True
     install_recommends: False
@@ -77,9 +81,20 @@
   with_items: "{{ docker_users }}"
   when: docker_users
 
+- name: Get information about indicated docker-compose version
+  uri:
+    url: "https://api.github.com/repos/docker/compose/releases/{{docker_compose_version}}"
+    return_content: yes
+  register: github_response
+
+- set_fact:
+    docker_compose_url: "{{  github_response.json.assets|json_query(query) }}"
+  vars:
+    query: "[?name=='docker-compose-Linux-x86_64'].url | [0]"
+
 - name: Install Docker Compose
   get_url:
-    url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-Linux-x86_64"
+    url: "{{docker_compose_url}}"
     dest: "/usr/local/bin/docker-compose"
     force: True
     owner: "root"


### PR DESCRIPTION
This PR changes the behaviour of the role to install the latest version available, if not specified differently. This addresses problems described in #20 and #26.