### PR TITLE
fix deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Fail if Docker version is < 17.03
   fail:
     msg: "docker_version must be >= 17.03, yours is set to {{ docker_version }}."
-  when: docker_version | version_compare("17.03", "<")
+  when: docker_version is version("17.03", "<")
 
 - name: Install Docker and role dependencies
   apt:


### PR DESCRIPTION
When executing this playbook with ansible 2.5.1, a deprecation warning is raised:
```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|version_compare` instead use `result is version_compare`. This feature will be removed in version 2.9. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This pull requests fixes this warning.