### PR TITLE
#37 : Added variables for Debian and Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ latest release. [Switch to the latest release](https://github.com/nickjj/ansible
 The philosophy for all of my roles is to make it easy to get going, but provide
 a way to customize nearly everything.
 
+### Requirements for Ubuntu18.04
+- `Universe` repo needs to be enabled
+
 ### What's configured by default?
 
 The latest Docker CE will be installed, Docker Compose will be installed, Docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,8 @@ docker__daemon_environment: []
 
 docker__systemd_override: ""
 
+docker__package_dependencies: []
+
 docker__cron_jobs:
   - name: "Docker disk clean up"
     job: docker system prune -af &> /dev/null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,14 +37,6 @@ docker__cron_jobs:
     cron_file: "docker-disk-clean-up"
     user: "{{ (docker__users|first)|default('root') }}"
 
-docker__package_dependencies:
-  - "apt-transport-https"
-  - "ca-certificates"
-  - "cron"
-  - "gnupg2"
-  - "python-pip"
-  - "software-properties-common"
-
 docker__apt_key_id: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 docker__apt_key_server: "https://download.docker.com/linux/{{ ansible_distribution|lower }}/gpg"  # yamllint disable-line rule:line-length
 docker__apt_repository: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Include Ubuntu-specific variables.
+  include_vars: "{{ ansible_distribution }}.yml"
+  when: 
+  - ansible_distribution == 'Ubuntu'
+  - ansible_os_family == 'Debian'
+
+- name: Include Debian-specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
+  when:
+  - ansible_os_family == 'Debian'
+  - ansible_distribution != 'Ubuntu'
 
 - name: Disable pinned Docker version
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,10 @@
 
 - name: Install role dependencies
   apt:
+    name: "{{ _docker__package_dependencies }}"
+
+- name: Install user role dependencies
+  apt:
     name: "{{ docker__package_dependencies }}"
 
 - name: Pip install docker for Ansible's docker_login and docker_service modules

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,8 @@
+docker__package_dependencies:
+  - "apt-transport-https"
+  - "ca-certificates"
+  - "curl"
+  - "cron"
+  - "gnupg2"
+  - "python-pip"
+  - "software-properties-common"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,4 @@
-docker__package_dependencies:
+_docker__package_dependencies:
   - "apt-transport-https"
   - "ca-certificates"
   - "curl"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,4 +1,4 @@
-docker__package_dependencies:
+_docker__package_dependencies:
   - "apt-transport-https"
   - "ca-certificates"
   - "curl"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,6 @@
+docker__package_dependencies:
+  - "apt-transport-https"
+  - "ca-certificates"
+  - "curl"
+  - "python-pip"
+  - "software-properties-common"


### PR DESCRIPTION
- Moved the dependencies variables from `default` folder to `vars` folder, this would help in the future to support multiple platforms that are outside of Debian ecosystem.
- Removed `gnupg2` from Ubuntu install.
- Added to `README.md` the requirement section which specifies for Ubuntu18.04 users to enable Universe.

**This would only fix "part" of the problem**, _maybe a further separation of tasks and variables needs to be done to ensure full compatibility with Ubuntu18.04 clean server installs._

Initially I wanted to add the `universe` repo sources list but I realized that it was out of scope of your ethic for this role; it could've impacted people that work on different sources and it is, in the end, out of the scope of this role.

I know we have discussed in the topic issue regarding `gnupg2` but it is not required in a base install as opposed to `python-pip`s importance.
Python-pip is as well in the `universe` repo source list, so the warning should be on the `README.md` section until Canonical offers a way to install the repos during a clean install of Ubuntu18.04.
