### PR TITLE
[Install Docker's dependencies step]Fix 404 while not updating cache

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Install Docker's dependencies
   apt:
     name: "{{ docker__package_dependencies + docker__pip_dependencies }}"
+    update_cache: yes
 
 - name: Add Docker's public PGP key to the APT keyring
   apt_key:


### PR DESCRIPTION
Hi, 

Little contribution, when you don't update cache while installing `Install Docker's dependencies` step you'll get a shitload of 404 for every single packages,. 

Easy fix : you can just update_cache: yes that will trigger an apt update right before and fix the issue. 
[https://ibb.co/sPj3Xw4](url)