### PR TITLE
Update apt cache when installing dependencies

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Install Docker's dependencies
   apt:
     name: "{{ docker__package_dependencies + docker__pip_dependencies }}"
+    update_cache: yes
 
 - name: Add Docker's public PGP key to the APT keyring
   apt_key:


### PR DESCRIPTION
Fixes an issue where the role fails on freshly provisioned machines because `apt update` never ran.