### PR TITLE
Fix small typo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   apt:
     name: "{{ docker__package_dependencies + docker__pip_dependencies }}"
 
-- name: Add Docker's public PGP key to the APT keyring
+- name: Add Docker's public GPG key to the APT keyring
   apt_key:
     id: "{{ docker__apt_key_id }}"
     url: "{{ docker__apt_key_url }}"


### PR DESCRIPTION
Replace `PGP` with `GPG`, according to the docker url in:

https://github.com/nickjj/ansible-docker/blob/f59011a195e7aceed824d2ba6e92d7f97acfde18/defaults/main.yml#L42