### PR TITLE
Update the apt cache before the first package install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Install Docker's dependencies
   apt:
     name: "{{ docker__package_dependencies + docker__pip_dependencies }}"
+    update_cache: true
 
 - name: Add Docker's public GPG key to the APT keyring
   apt_key:


### PR DESCRIPTION
When running simply this role on a DigitalOcean droplet, the role failed
with:

```
FAILED! => {"changed": false, "msg": "No package matching 'python3-pip'
    is available"}""}
```

After adding this, that error no longer appears and the role completes
successfully. This is akin to the start of the travis tests:

https://github.com/nickjj/ansible-docker/blob/master/tests/test.yml#L38-L41