### PR TITLE
Feature/pipproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,16 @@ docker__apt_repository: >
 
 ### Installing Python packages with Virtualenv and PIP
 
+#### PIP extra args and environemt
+
+When you have the pain of an corporate proxy or just want to set some pip specialities use this:
+
+```yml
+docker__pip_environment: 
+    - https_proxy: http://user:password@host:port
+docker__pip_extra_args: "--trusted-host pypi.org --trusted-host files.pythonhosted.org"
+```
+
 #### Configuring Virtualenv
 
 Rather than pollute your server's version of Python, all PIP packages are

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,9 @@ docker__pip_dependencies:
   - "python-setuptools"
   - "python{{ '3' if ansible_python.version.major == 3 else '' }}-pip"
 
+docker__pip_environment: []
+docker__pip_extra_args: ""
+
 docker__pip_virtualenv: "/usr/local/lib/docker/virtualenv"
 
 docker__default_pip_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,7 @@ docker__pip_environment: []
 docker__pip_extra_args: ""
 
 docker__pip_virtualenv: "/usr/local/lib/docker/virtualenv"
+docker__pip_virtualenv_command: "virtualenv"
 
 docker__default_pip_packages:
   - name: "docker"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,7 @@
     name: >
       {{ item.name }}{% if item.version | d() %}=={{ item.version }}{% endif %}
     virtualenv: "{{ docker__pip_virtualenv }}"
+    virtualenv_command: "{{ docker__pip_virtualenv_command }}"
     state: "{{ item.state | d('present') }}"
     extra_args: "{{ docker__pip_extra_args }}"
   environment: "{{ docker__pip_environment }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,9 @@
 - name: Install Virtualenv
   pip:
     name: "virtualenv"
+    extra_args: "{{ docker__pip_extra_args }}"
+  environment: "{{ docker__pip_environment }}"
+
 
 - name: Install Python packages
   pip:
@@ -44,6 +47,8 @@
       {{ item.name }}{% if item.version | d() %}=={{ item.version }}{% endif %}
     virtualenv: "{{ docker__pip_virtualenv }}"
     state: "{{ item.state | d('present') }}"
+    extra_args: "{{ docker__pip_extra_args }}"
+  environment: "{{ docker__pip_environment }}"
   loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
   when: item.name | d()
 


### PR DESCRIPTION
Why i have done this pr:
To use the role behind a corporate proxy.

Things done:
- Added pip extra args 
- Added pip environment var 
- Virtualenv was not working under ubuntu 18.04 behind proxy. Now its possible to change the command to `python3 -m venv`
