### PR TITLE
Add apt cache updating before installing packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Install Docker's dependencies
   apt:
     name: "{{ docker__package_dependencies + docker__pip_dependencies }}"
+    update_cache: yes
 
 - name: Add Docker's public GPG key to the APT keyring
   apt_key:


### PR DESCRIPTION
You can get following error if your never updated apt cache before executing the role:

    TASK [nickjj.docker : Install Docker's dependencies] *****************************************************************
    task path: /home/ksh/Projects/fls_management_api/ansible/roles/nickjj.docker/tasks/main.yml:18
    fatal: [fls_backend]: FAILED! => {"changed": false, "msg": "No package matching 'python3-pip' is available"}