### PR TITLE
Fix idempotencies failures

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,7 @@ docker__apt_repository: >
 
 docker__pip_dependencies:
   - "gcc"
-  - "python-setuptools"
+  - "python{{ '3' if ansible_python.version.major == 3 else '' }}-setuptools"
   - "python{{ '3' if ansible_python.version.major == 3 else '' }}-dev"
   - "python{{ '3' if ansible_python.version.major == 3 else '' }}-pip"
   - "virtualenv"


### PR DESCRIPTION
Without the fix, dependency python-setuptools forces install of Python 2. Then the second run to test idempotency uses Python 2 (instead of Python 3) and fails because of new Python dependency to be installed.