### PR TITLE
add var to set python's virtualenv command

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,7 @@ docker__pip_dependencies:
   - "virtualenv"
 
 docker__pip_virtualenv: "/usr/local/lib/docker/virtualenv"
+docker__pip_virtualenv_command: "virtualenv"
 
 docker__default_pip_packages:
   - name: "docker"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,16 +39,10 @@
     name: >
       {{ item.name }}{% if item.version | d() %}=={{ item.version }}{% endif %}
     virtualenv: "{{ docker__pip_virtualenv }}"
+    virtualenv_command: "{{ docker__pip_virtualenv_command }}"
     state: "{{ item.state | d('present') }}"
   loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
   when: item.name | d()
-
-- name: Symlink Python binary to /usr/local/bin/python-docker
-  file:
-    path: "/usr/local/bin/python-docker"
-    src: "{{ docker__pip_virtualenv }}/bin/python"
-    force: true
-    state: "link"
 
 - name: Symlink selected Python package binaries to /usr/local/bin
   file:
@@ -144,7 +138,7 @@
   loop: "{{ docker__registries }}"
   when: item.username | d() and item.password | d()
   vars:
-    ansible_python_interpreter: "{{ '/usr/bin/env python-docker' }}"
+    ansible_python_interpreter: "{{ docker__pip_virtualenv + '/bin/python' + ('3' if ansible_python.version.major == 3 else '') }}"
 
 - name: Remove Docker related cron jobs
   file:


### PR DESCRIPTION
I had problems running the role on a bare-bones Ubuntu 18.04 without python2. The task "Install Python packages" was using the `virtualenv` command, which was not available on the system, leading to the error:
```
Failed to find required executable virtualenv in paths: ...
```

[This issue](https://github.com/ansible/ansible/issues/52275) describes the error in more detail. **TL;DR:** use `python3 -m venv` instead of `virtualenv` for the `virtualenv_command` parameter.

In this PR I created the variable `docker__pip_virtualenv_command`, which lets the user decide which virtualenv command to use.

Furthermore i removed the symlink as it does not seem to work with the new virtualenv command:
```
user@test:~$ ls -la /usr/local/bin/python-docker 
lrwxrwxrwx 1 root root 44 Mär 21 14:16 /usr/local/bin/python-docker -> /usr/local/lib/docker/virtualenv/bin/python3

user@test:~$ /usr/local/bin/python-docker -m docker   # this does not work
/usr/local/bin/python-docker: No module named docker

user@test:~$ /usr/local/lib/docker/virtualenv/bin/python3 -m docker   # this works
/usr/local/lib/docker/virtualenv/bin/python3: No module named docker.__main__; 'docker' is a package and cannot be directly executed
```

If you think it's a valid fix, I will update the documentation and look into the symlink issue.