### PR TITLE
Set up config before installing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Backwards incompatible change:** `python-docker` was renamed to `python3-docker`
 - Fix symlink related issues with virtualenv when using virtualenv 20+
+- Configure daemon before installing Docker to allow customizing certain things
 - Remove all support for Python 2.x
 - Officially remove support for Ubuntu 16.04
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     repo: "{{ docker__apt_repository }}"
     update_cache: true
 
-- name: Create Docker configuration directory
+- name: Create Docker configuration directories
   file:
     path: "{{ item }}"
     state: "directory"
@@ -38,6 +38,7 @@
     mode: "0755"
   loop:
     - "/etc/docker"
+    - "/etc/systemd/system/docker.service.d"
 
 - name: Configure Docker daemon options (json)
   template:
@@ -86,16 +87,6 @@
     groups: "docker"
     append: true
   loop: "{{ docker__users }}"
-
-- name: Create Docker configuration directory
-  file:
-    path: "{{ item }}"
-    state: "directory"
-    owner: "root"
-    group: "root"
-    mode: "0755"
-  loop:
-    - "/etc/systemd/system/docker.service.d"
 
 - name: Configure Docker daemon options (flags)
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,25 @@
     repo: "{{ docker__apt_repository }}"
     update_cache: true
 
+- name: Create Docker configuration directory
+  file:
+    path: "{{ item }}"
+    state: "directory"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  loop:
+    - "/etc/docker"
+
+- name: Configure Docker daemon options (json)
+  template:
+    src: "etc/docker/daemon.json.j2"
+    dest: "/etc/docker/daemon.json"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  when: docker__default_daemon_json | d() or docker__daemon_json | d()
+
 - name: Install Docker
   apt:
     name: "docker-{{ docker__edition }}"
@@ -68,7 +87,7 @@
     append: true
   loop: "{{ docker__users }}"
 
-- name: Create Docker configuration directories
+- name: Create Docker configuration directory
   file:
     path: "{{ item }}"
     state: "directory"
@@ -76,18 +95,7 @@
     group: "root"
     mode: "0755"
   loop:
-    - "/etc/docker"
     - "/etc/systemd/system/docker.service.d"
-
-- name: Configure Docker daemon options (json)
-  template:
-    src: "etc/docker/daemon.json.j2"
-    dest: "/etc/docker/daemon.json"
-    owner: "root"
-    group: "root"
-    mode: "0644"
-  when: docker__default_daemon_json | d() or docker__daemon_json | d()
-  notify: ["Restart Docker"]
 
 - name: Configure Docker daemon options (flags)
   template:


### PR DESCRIPTION
This moves the creation of `daemon.json` to before Docker gets installed. This ensures that if `graph` is defined then Docker immediately uses it and initialises its workspace in the desired location.

Note that this change does not support `graph` being changed after Docker has been installed. More work is required for that :)
