### PR TITLE
Split out architecture to support ARM64 and support further overrides

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,10 +39,12 @@ docker__package_dependencies:
   - "gnupg2"
   - "software-properties-common"
 
+docker__arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+
 docker__apt_key_id: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 docker__apt_key_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
 docker__apt_repository: >
-  deb [arch=amd64]
+  deb [arch={{ docker__arch }}]
   https://download.docker.com/linux/{{ ansible_distribution | lower }}
   {{ ansible_distribution_release }} {{ docker__channel | join (' ') }}
 


### PR DESCRIPTION
With the release of Amazon's new Graviton ARM64 processor, I wanted to be able to use Ansible to deploy Docker to it.

This two-line change separates the architecture setting from the repository setting. It adds support for ARM64 and, by defining a default value, allows that value to be overridden by a host-var or similar, without needed to replace the entire `docker__apt_repository` string.
