### PR TITLE
Fix missing aarch64 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ docker__package_dependencies:
 # Ansible identifies CPU architectures differently than Docker.
 docker__architecture_map:
   "x86_64": "amd64"
+  "aarch64": "arm64"
   "aarch": "arm64"
   "armhf": "armhf"
   "armv7l": "armhf"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,7 @@ docker__package_dependencies:
 
 docker__architecture_map:
   "x86_64": "amd64"
+  "aarch64": "arm64"
   "aarch": "arm64"
   "armhf": "armhf"
   "armv7l": "armhf"


### PR DESCRIPTION
A raspberry pi with 64bit chip and ubuntu uses the string "aarch64".

Also see https://en.wikipedia.org/wiki/AArch64
"AArch64 or ARM64 is the 64-bit extension of the ARM architecture"