### PR TITLE
Make ansible delete the old apt preference control file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Remove old preference control file
+  file:
+    path: "/etc/apt/preferences.d/docker-ce.pref"
+    state: "absent"
+
 - name: Disable pinned Docker version
   file:
     dest: "/etc/apt/preferences.d/docker.pref"


### PR DESCRIPTION
Hi,

after updating your role to the latest version, I've ended up having two apt preference files on my servers, thus apt dit not update docker to the defined version. This is due to the file name change in 067fdb4. Do you mind adding my check to delete the old file 'docker-ce.pref'?

```
➜  preferences.d ls -alh
-rw-r--r-- 1 root root  112  1. Jan 2019  docker-ce.pref
-rw-r--r-- 1 root root  113 25. Aug 11:18 docker.pref
```

```
➜  apt cat /etc/apt/preferences.d/docker-ce.pref
Explanation: Pin added by Ansible role "nickjj.docker"
Package: docker-ce
Pin: version 18.06*
Pin-Priority: 600
➜  apt cat /etc/apt/preferences.d/docker.pref
Explanation: Pin added by Ansible role "nickjj.docker"
Package: docker-ce*
Pin: version 20.10*
Pin-Priority: 600
```