### PR TITLE
replace reload systemd daemon task by a handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,4 @@
   systemd:
     name: "docker"
     state: "restarted"
-
-- name: Reload systemd daemon
-  systemd:
     daemon_reload: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,7 @@
   systemd:
     name: "docker"
     state: "restarted"
+
+- name: Reload systemd daemon
+  systemd:
+    daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,13 +117,12 @@
   stat:
     path: "/etc/systemd/system/docker.service.d/environment.conf"
   register: docker__register_daemon_environment
-  when: not docker__daemon_environment
 
 - name: Remove environment file when removing all environment variables
   file:
     path: "/etc/systemd/system/docker.service.d/environment.conf"
     state: "absent"
-  when: docker__register_daemon_environment.stat.exists and not docker__daemon_environment
+  when: docker__register_daemon_environment.stat.exists and not docker__daemon_environment | d()
   notify:
     - "Restart Docker"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,8 +109,20 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  register: docker__register_daemon_environment
   when: docker__daemon_environment | d()
+  notify:
+    - "Restart Docker"
+
+- name: Get environment file status 
+  stat:
+    path: "/etc/systemd/system/docker.service.d/environment.conf"
+  register: docker__register_daemon_environment
+
+- name: Remove environment file when removing all environement variables
+  file:
+    path: "/etc/systemd/system/docker.service.d/environment.conf"
+    state: "absent"
+  when: docker__register_daemon_environment.stat.exists and not docker__daemon_environment
   notify:
     - "Restart Docker"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,7 +100,6 @@
   register: docker__register_daemon_flags
   when: docker__daemon_flags | d()
   notify:
-    - "Reload systemd daemon"
     - "Restart Docker"
 
 - name: Configure Docker daemon environment variables
@@ -113,7 +112,6 @@
   register: docker__register_daemon_environment
   when: docker__daemon_environment | d()
   notify:
-    - "Reload systemd daemon"
     - "Restart Docker"
 
 - name: Configure custom systemd unit file override
@@ -126,7 +124,6 @@
   register: docker__register_custom_override
   when: docker__systemd_override | d()
   notify:
-    - "Reload systemd daemon"
     - "Restart Docker"
 
 - name: Restart Docker now to make sure `docker login` works

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,8 +117,9 @@
   stat:
     path: "/etc/systemd/system/docker.service.d/environment.conf"
   register: docker__register_daemon_environment
+  when: not docker__daemon_environment
 
-- name: Remove environment file when removing all environement variables
+- name: Remove environment file when removing all environment variables
   file:
     path: "/etc/systemd/system/docker.service.d/environment.conf"
     state: "absent"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,7 +99,9 @@
     mode: "0644"
   register: docker__register_daemon_flags
   when: docker__daemon_flags | d()
-  notify: ["Restart Docker"]
+  notify:
+    - "Reload systemd daemon"
+    - "Restart Docker"
 
 - name: Configure Docker daemon environment variables
   template:
@@ -110,7 +112,9 @@
     mode: "0644"
   register: docker__register_daemon_environment
   when: docker__daemon_environment | d()
-  notify: ["Restart Docker"]
+  notify:
+    - "Reload systemd daemon"
+    - "Restart Docker"
 
 - name: Configure custom systemd unit file override
   template:
@@ -121,14 +125,9 @@
     mode: "0644"
   register: docker__register_custom_override
   when: docker__systemd_override | d()
-  notify: ["Restart Docker"]
-
-- name: Reload systemd daemon
-  systemd:
-    daemon_reload: true
-  when: docker__register_daemon_flags is changed
-        or docker__register_daemon_environment is changed
-        or docker__register_custom_override is changed
+  notify:
+    - "Reload systemd daemon"
+    - "Restart Docker"
 
 - name: Restart Docker now to make sure `docker login` works
   meta: "flush_handlers"


### PR DESCRIPTION
Hi @nickjj ,
When I checked a playbook using your role with ansible-lint, i had an error :
```
no-handler: Tasks that run when changed should likely be handlers
../../.cache/ansible-lint/198db2/roles/nickjj.docker/tasks/main.yml:126 Task/Handler: Reload systemd daemon
```
To fix this message i change the task by a handler.