### PR TITLE
Add rescue option for OS upgrade failure + test via docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,15 @@ jobs:
           ./tests/test.sh
         env:
           distro: ${{ matrix.distro }}
+
+  upgrade-test:
+    runs-on: "ubuntu-20.04"
+    steps:
+      - uses: "actions/checkout@v2"
+
+    - name: "Run upgrade test"
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: false
+        file: tests/Dockerfile

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,8 @@ docker__daemon_flags:
 docker__daemon_environment: []
 
 docker__systemd_override: ""
+docker__systemd_restart: true # toggle off if you have a system without systemd
+docker__restart: true         # toggle off if you have a system you can't restart docker on (docker build environment for example)
 
 docker__cron_jobs_prune_flags: "af"
 docker__cron_jobs_prune_schedule: ["0", "0", "*", "*", "0"]

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,8 +3,10 @@
 - name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: true
+  when: docker__restart
 
 - name: Restart Docker
   ansible.builtin.systemd:
     name: "docker"
     state: "restarted"
+  when: docker__systemd_restart

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,15 +75,22 @@
       - "docker-compose-plugin"
     state: "{{ docker__state }}"
 
-- name: Install Python packages
-  ansible.builtin.pip:
-    name: >
-      {{ item.name }}{% if item.version | d() %}=={{ item.version }}{% endif %}
-    virtualenv: "{{ docker__pip_virtualenv }}"
-    virtualenv_python: "python3"
-    state: "{{ item.state | d('present') }}"
-  loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
-  when: item.name | d()
+- block:
+    - name: Install Python packages
+      ansible.builtin.pip:
+        name: >
+          {{ item.name }}{% if item.version | d() %}=={{ item.version }}{% endif %}
+        virtualenv: "{{ docker__pip_virtualenv }}"
+        virtualenv_python: "python3"
+        state: "{{ item.state | d('present') }}"
+      loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
+      when: item.name | d()
+  rescue:
+    - name: Handle upgrade case
+      ansible.builtin.file:
+        path: /usr/local/lib/docker/virtualenv
+        state: absent
+    - include_tasks: main.yml
 
 - name: Create python3-docker proxy script to access the Virtualenv's interpreter
   ansible.builtin.template:

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,48 @@
+###################################
+# first run the playbook on the "older pre-upgrade os"
+FROM ubuntu:20.04 as old
+WORKDIR /etc/ansible/roles/role_under_test
+
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  software-properties-common
+
+# get newer ansible than in default ubuntu
+RUN apt-add-repository -y ppa:ansible/ansible
+
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  ansible
+
+# Install Ansible inventory file.
+RUN mkdir -p /etc/ansible
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+COPY . /etc/ansible/roles/role_under_test
+
+# run the playbook
+RUN ansible-playbook tests/test.yml
+
+
+##############################
+# copy the virualenv over to the new "upgraded" os and try to run again
+# as if we have done an upgrade without clearing the virtualenv
+FROM ubuntu:22.04 as new
+COPY --from=old /usr/local/lib/docker/virtualenv /usr/local/lib/docker/virtualenv
+WORKDIR /etc/ansible/roles/role_under_test
+
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  software-properties-common gpg-agent
+
+# get newer ansible than in default ubuntu
+RUN apt-add-repository -y ppa:ansible/ansible
+
+RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  ansible
+
+# Install Ansible inventory file.
+RUN mkdir -p /etc/ansible
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+COPY . /etc/ansible/roles/role_under_test
+
+# run the playbook
+RUN ansible-playbook tests/test.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -28,6 +28,8 @@
       [Service]
       ThisIsJust=ATest
 
+    docker__systemd_restart: false
+
   roles:
     - role: "role_under_test"
 


### PR DESCRIPTION
A first pass at trying to solve: https://github.com/nickjj/ansible-docker/issues/117

I was able to reproduce the failure mode reliably with the added Dockerfile.

You can try it out by running:
`docker build -f tests/Dockerifle .` from the main folder of the repo.

The dockerfile uses multistage builds. In the first stage, it uses Ubuntu20.04, applies the playbook. Then in the next stage, it starts from Ubuntu22.04, and then copies the virtualenv from the previous stage, as if an upgrade had been done without cleaning this up. It then tries to run the playbook again and then fails.

I converted the failing task to a `block` and `rescue`, and then when the rescue happens, it clobbers the virtual env and then just tries to apply the playbook again. This appears to work succesfully.

The only hangup I had, was trying to apply the playbook during a docker build - there is no systemd and docker can't run in a service while building, so I just added a couple of new default variables that toggle off the restart handlers.

Might not be the best way to do it, but open to suggestions!