### PR TITLE
add apt docker-{{ docker__edition }}-cli docker-{{ docker__edition }}-rootless-extras when updating

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,8 @@
   ansible.builtin.apt:
     name:
       - "docker-{{ docker__edition }}"
+      - "docker-{{ docker__edition }}-cli"
+      - "docker-{{ docker__edition }}-rootless-extras"
       - "docker-compose-plugin"
     state: "{{ docker__state }}"
 


### PR DESCRIPTION
When upgrading the docker version also upgrade docker-{{ docker__edition }}-cli docker-{{ docker__edition }}-rootless-extras