### PR TITLE
Fix for ubuntu 22.04 apt key deprecated error

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,10 +54,7 @@ docker__architecture_map:
 
 docker__apt_key_id: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 docker__apt_key_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
-docker__apt_repository: >
-  deb [arch={{ docker__architecture_map[ansible_architecture] }}]
-  https://download.docker.com/linux/{{ ansible_distribution | lower }}
-  {{ ansible_distribution_release }} {{ docker__channel | join (' ') }}
+docker__apt_repository: "deb [arch={{ docker__architecture_map[ansible_architecture] }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ docker__channel | join (' ') }}"
 
 docker__pip_dependencies:
   - "gcc"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,14 +36,23 @@
   ansible.builtin.apt:
     name: "{{ docker__package_dependencies + docker__pip_dependencies }}"
 
+- name: Create /etc/apt/keyrings/ directory if not exist
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/
+    state: directory
+    mode: '0755'
+
 - name: Add Docker's public GPG key to the APT keyring
-  ansible.builtin.apt_key:
-    id: "{{ docker__apt_key_id }}"
+  ansible.builtin.get_url:
     url: "{{ docker__apt_key_url }}"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+    force: true
 
 - name: Configure Docker's upstream APT repository
   ansible.builtin.apt_repository:
     repo: "{{ docker__apt_repository }}"
+    filename: docker
     update_cache: true
 
 - name: Create Docker configuration directories


### PR DESCRIPTION
### Error to fix
Current version of role uses `ansible.builtin.apt_key` to add Dockers public GPG key to the APT keyring. This causes following error when running `apt update` on Ubuntu 22.04 (and Debian 11?): ` Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.`
Read more about the why this is [here in the summary](https://github.com/ansible/ansible/issues/78063#issue-1272353723)


### Fix
* Added `signed-by=/etc/apt/keyrings/docker.asc` to `docker__apt_repository` variable
* Changed `ansible.builtin.apt_key` module to `ansible.builtin.get_url` module to download and save GPG key. 
  * **Note:** saved as **.asc** filetype [See](https://github.com/ansible/ansible/issues/78063#issuecomment-1235291720)
* Added task to create `/etc/apt/keyrings/` directory just in case it doesn't exit

**Read More / References**:
[ansible.builtin.apt_key adds keys to a deprecated location #78063 ](https://github.com/ansible/ansible/issues/78063)
[apt_key deprecated in Debian/Ubuntu - how to fix in Ansible](https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible)
[Used this commit as reference for the fix](https://github.com/tonyclemmey/ansible-role-mongodb/commit/ca676ed235f21de8041ec2f99baeadc02e08248b)