### PR TITLE
Explicitly install Docker CLI and rootless extras

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,6 +84,8 @@
   ansible.builtin.apt:
     name:
       - "docker-ce"
+      - "docker-ce-cli"
+      - "docker-ce-rootless-extras"
       - "docker-compose-plugin"
     state: "{{ docker__state }}"
 


### PR DESCRIPTION
Without doing this these packages won't get updated when you install a new version of Docker.

Submitting the same change as https://github.com/nickjj/ansible-docker/pull/122

I ran into the issue and found the p-r above, so I have confirmed it in my environment.

It is mentioned that `docker-cli-*` needs to be pinned separately in [the last comment](https://github.com/nickjj/ansible-docker/pull/122#issuecomment-1285249536) of the issue. However, it seems this is not necessary because the CLI package name is now `docker-ce-cli` instead of `docker-cli`.