### PR TITLE
Ansible 12 compatibility (implicit boolean conversion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix Ansible 12 compatibility by updating conditionals to use proper boolean evaluation
+
 ## v2.5.1
 
 *Released: June 18th 2025*

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
   ansible.builtin.file:
     dest: "/etc/apt/preferences.d/docker.pref"
     state: "absent"
-  when: not docker__version | d()
+  when: not ((docker__version | d("")) is truthy)
 
 - name: Disable pinned Docker Compose v2 version
   ansible.builtin.file:
     dest: "/etc/apt/preferences.d/docker-compose-plugin.pref"
     state: "absent"
-  when: not docker__compose_v2_version | d()
+  when: not ((docker__compose_v2_version | d("")) is truthy)
 
 - name: Enable pinned Docker version
   ansible.builtin.template:
@@ -18,7 +18,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  when: docker__version | d()
+  when: (docker__version | d("")) is truthy
 
 - name: Enable pinned Docker Compose v2 version
   ansible.builtin.template:
@@ -27,7 +27,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  when: docker__compose_v2_version | d()
+  when: (docker__compose_v2_version | d("")) is truthy
 
 - name: Install Docker's dependencies
   retries: 20
@@ -96,7 +96,7 @@
     virtualenv_python: "python3"
     state: "{{ item.state | d('present') }}"
   loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
-  when: item.name | d()
+  when: (item.name | d("")) is truthy
 
 - name: Create python3-docker proxy script to access Virtualenv's interpreter
   ansible.builtin.template:
@@ -115,7 +115,7 @@
   loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
   when:
     - item.state | d("present") != "absent"
-    - item.path | d() and item.src | d()
+    - ((item.path | d("")) is truthy) and ((item.src | d("")) is truthy)
 
 - name: Add user(s) to "docker" group
   ansible.builtin.user:
@@ -168,7 +168,7 @@
   loop: "{{ docker__registries }}"
   loop_control:
     label: '{{ {"registry_url": item.registry_url | d("https://index.docker.io/v1/"), "username": item.username, "state": item.state | d("present")} }}' # yamllint disable-line rule:line-length
-  when: item.username | d() and item.password | d()
+  when: ((item.username | d("")) is truthy) and ((item.password | d("")) is truthy)
   become: true
   become_user: "{{ docker__login_become_user | d('root') }}"
   vars:
@@ -181,7 +181,7 @@
   loop: "{{ docker__cron_jobs }}"
   when:
     - item.state | d("present") == "absent"
-    - item.cron_file | d()
+    - (item.cron_file | d("")) is truthy
 
 - name: Create Docker related cron jobs
   ansible.builtin.cron:
@@ -197,5 +197,5 @@
   loop: "{{ docker__cron_jobs }}"
   when:
     - item.state | d("present") != "absent"
-    - item.name | d() and item.job | d()
-    - item.schedule | d() and item.cron_file | d()
+    - ((item.name | d("")) is truthy) and ((item.job | d("")) is truthy)
+    - ((item.schedule | d("")) is truthy) and ((item.cron_file | d("")) is truthy)


### PR DESCRIPTION
This PR fixes compatibility issues with Ansible 12 by updating conditional statements to use proper boolean evaluation. It fixes "Conditionals must have a boolean result" error.

Changes:
- Updated conditionals from `when: var | d()` to `when: (var | d("")) | is truthy` for string variables

See https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_12.html#example-implicit-boolean-conversion

