### PR TITLE
Omit dependency software-properties-common on Debian 13+

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ docker__package_dependencies:
   - "ca-certificates"
   - "cron"
   - "gnupg2"
-  - "software-properties-common"
+  - "{{ 'software-properties-common' if ansible_distribution != 'Debian' or (ansible_distribution == 'Debian' and ansible_distribution_major_version|int <= 12) else omit }}"
 
 docker__architecture_map:
   "x86_64": "amd64"


### PR DESCRIPTION
As the dependency `software-properties-common` has been removed in Debian Trixie (13), I suggest adjusting the requirement accordingly.

- https://tracker.debian.org/news/1579223/software-properties-removed-from-testing/

This fixes #131.